### PR TITLE
fix the following image vulnerabilities:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apk update && \
     apk add supervisor && \
     apk add --update py2-pip && \
     apk add --no-cache bash && \
-    apk add --no-cache --virtual .build-deps bzip2-dev gcc libc-dev libffi-dev openssl-dev python3-dev make
+    apk add --no-cache --virtual .build-deps bzip2-dev gcc libc-dev libffi-dev openssl-dev python3-dev make && \
+    apk upgrade "expat==2.2.8-r0"
 
 # Copy project sources
 COPY . /src
@@ -16,7 +17,8 @@ COPY . /src
 WORKDIR /src
 
 # Install app dependencies and create supervisord dirs
-RUN pip3 install -U -r requirements.txt && \
+RUN pip3 install --upgrade pip==21.3.1 && \
+    pip3 install -U -r requirements.txt && \
     pip3 install gunicorn==19.7.1 && \
     mkdir -p /etc/supervisor/conf.d /var/log/supervisor /var/run/supervisor
 


### PR DESCRIPTION
✗ Medium severity vulnerability found in e2fsprogs/libcom_err
  Description: Out-of-bounds Write
  Info: https://snyk.io/vuln/SNYK-ALPINE37-E2FSPROGS-493456
  Introduced through: e2fsprogs/libcom_err@1.43.7-r0, krb5-conf/krb5-conf@1.0-r1
  From: e2fsprogs/libcom_err@1.43.7-r0
  From: krb5-conf/krb5-conf@1.0-r1 > krb5/krb5-libs@1.15.4-r0 > e2fsprogs/libcom_err@1.43.7-r0
  Image layer: Introduced by your base image (python:3.6.8-alpine3.7)
  Fixed in: 1.43.7-r1

✗ High severity vulnerability found in expat/expat
  Description: XML External Entity (XXE) Injection
  Info: https://snyk.io/vuln/SNYK-ALPINE37-EXPAT-453374
  Introduced through: expat/expat@2.2.5-r0, .python-rundeps@0, python2/python2@2.7.15-r2, python3/python3@3.6.9-r1
  From: expat/expat@2.2.5-r0
  From: .python-rundeps@0 > expat/expat@2.2.5-r0
  From: python2/python2@2.7.15-r2 > expat/expat@2.2.5-r0
  and 1 more...
  Image layer: Introduced by your base image (python:3.6.8-alpine3.7)
  Fixed in: 2.2.7-r0

✗ High severity vulnerability found in expat/expat
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-ALPINE37-EXPAT-489399
  Introduced through: expat/expat@2.2.5-r0, .python-rundeps@0, python2/python2@2.7.15-r2, python3/python3@3.6.9-r1
  From: expat/expat@2.2.5-r0
  From: .python-rundeps@0 > expat/expat@2.2.5-r0
  From: python2/python2@2.7.15-r2 > expat/expat@2.2.5-r0
  and 1 more...
  Image layer: Introduced by your base image (python:3.6.8-alpine3.7)
  Fixed in: 2.2.7-r1

✗ Critical severity vulnerability found in sqlite/sqlite-libs
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-ALPINE37-SQLITE-458200
  Introduced through: sqlite/sqlite-libs@3.25.3-r0, .python-rundeps@0, python2/python2@2.7.15-r2, python3/python3@3.6.9-r1
  From: sqlite/sqlite-libs@3.25.3-r0
  From: .python-rundeps@0 > sqlite/sqlite-libs@3.25.3-r0
  From: python2/python2@2.7.15-r2 > sqlite/sqlite-libs@3.25.3-r0
  and 1 more...
  Image layer: Introduced by your base image (python:3.6.8-alpine3.7)
  Fixed in: 3.25.3-r1

# Instructions

Please try and perform pull requests against the ``develop`` branch. 

Merging against the master branch causes a new release to be deployed, and I'd like to avoid that on every PR.  

# PR Details

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->